### PR TITLE
Bump Gradle from 7.3 to 8.3

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build with Gradle
-        run: ./gradlew build pitest
+        run: ./gradlew build
       - run: mkdir mutation-testing-report && cp -r build/reports/pitest/* mutation-testing-report
       - name: Archive mutation testing results
         uses: actions/upload-artifact@v2

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,10 @@ tasks.named('test', Test) {
     useJUnitPlatform()
 }
 
+tasks.named('check') {
+    dependsOn 'pitest'
+}
+
 pitest {
     junit5PluginVersion = '1.1.2'
     timestampedReports = true

--- a/build.gradle
+++ b/build.gradle
@@ -10,17 +10,26 @@ repositories {
     mavenCentral()
 }
 
-dependencies {
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.9.2'
+// To upgrade Gradle, change gradleVersion and run task 'wrapper'
+tasks.named('wrapper', Wrapper) {
+    gradleVersion = 8.3
+    distributionType = Wrapper.DistributionType.ALL
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
+dependencies {
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.9.2'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
 
-tasks.withType(JavaCompile) {
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+}
+
+tasks.withType(JavaCompile).configureEach {
     options.encoding = 'UTF-8'
 }
 
-test {
+tasks.named('test', Test) {
     useJUnitPlatform()
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradlew
+++ b/gradlew
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 #
-# Copyright © 2015-2021 the original authors.
+# Copyright Â© 2015-2021 the original authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,10 +32,10 @@
 #       Busybox and similar reduced shells will NOT work, because this script
 #       requires all of these POSIX shell features:
 #         * functions;
-#         * expansions «$var», «${var}», «${var:-default}», «${var+SET}»,
-#           «${var#prefix}», «${var%suffix}», and «$( cmd )»;
-#         * compound commands having a testable exit status, especially «case»;
-#         * various built-in commands including «command», «set», and «ulimit».
+#         * expansions Â«$varÂ», Â«${var}Â», Â«${var:-default}Â», Â«${var+SET}Â»,
+#           Â«${var#prefix}Â», Â«${var%suffix}Â», and Â«$( cmd )Â»;
+#         * compound commands having a testable exit status, especially Â«caseÂ»;
+#         * various built-in commands including Â«commandÂ», Â«setÂ», and Â«ulimitÂ».
 #
 #   Important for patching:
 #


### PR DESCRIPTION
- https://docs.gradle.org/8.3/userguide/upgrading_version_7.html
- https://docs.gradle.org/8.3/userguide/upgrading_version_8.html
  - Deprecated java plugin conventions
  - Relying on automatic test framework implementation dependencies